### PR TITLE
Fix tavis ci build

### DIFF
--- a/lib/ecosystem.js
+++ b/lib/ecosystem.js
@@ -70,7 +70,7 @@ module.exports = {
       const wd = path.resolve(process.cwd(), repo.name)
       return new Promise((resolve, reject) => {
         console.log('>> npm install', repo.name)
-        const proc = spawnSync(npm, [ 'install', '--no-progress', '-q', '--force' ], {
+        const proc = spawnSync(npm, [ 'install', '--no-progress', '--force', '-d' ], {
           cwd: wd,
           stdio: [
             'ignore',

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   },
   "homepage": "https://github.com/trailsjs/smokesignals#readme",
   "dependencies": {
-    "lodash": "^4.12.0",
-    "trailpack": "^1.0.0-beta-1",
-    "trails": "^1.0.0-beta-10"
+    "lodash": "^4.16.4",
+    "trailpack": "^1.0.5",
+    "trails": "^1.1.0"
   },
   "devDependencies": {
-    "eslint": "^2.4.0",
-    "eslint-config-trails": "^1.0.4",
-    "mocha": "^2.3.4"
+    "eslint": "^3.7.1",
+    "eslint-config-trails": "^1.0.7",
+    "mocha": "^3.1.1"
   },
   "eslintConfig": {
     "extends": "trails"

--- a/test/trailpack.test.js
+++ b/test/trailpack.test.js
@@ -1,8 +1,5 @@
 'use strict'
 
-const assert = require('assert')
-const smokesignals = require('../')
-
 describe('Trailpack', () => {
   it('should be configurable', () => {
     //assert


### PR DESCRIPTION
Actually Travis CI is configured end and fail the process if the script dont update the log in 10 minutes, we can upgrade this number, but the problem is related to shared resources like the problem with the speed test in trails project.
A good solution is change the quiet mode of npm installs to info mode (No Verbose) for get more updates in the log and dont so easily reach the 10 minutes limit.
Also for us is more easy see the problems of the build process inside of travis if we have more info.
@tjwebb @trailsjs/devops please take a look.
